### PR TITLE
Upgrade to ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
       - main
 
 env:
-  # LLVM_VERSION: '18.1.7'
-  GCC_VERSION: '13'
-  CMAKE_VERSION: '3.30.1'
-  NINJA_VERSION: '1.10.1'
   VCPKG_COMMITTISH: 49ac2134b31b95b0ddf29d56873dcd24392691df
 
 jobs:
@@ -22,45 +18,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Set up clang-format
-      #   uses: aminya/setup-cpp@v1
-      #   with:
-      #     clangformat: ${{ env.LLVM_VERSION }}
+      - name: Install codespell and cmake-format
+        run: pip install codespell cmakelang
 
       - name: Print versions
         run: |
-          g++ --version
-          clang++ --version
-          clang-tidy --version
+          python --version
+          pip --version
+          cmake --version
           clang-format --version
-          g++-13 --version
-          clang++-18 --version
-          clang-tidy-18 --version
-          clang-format-18 --version
+          cmake-format --version
+          codespell --version
 
-      - name: Print installed apt packages
-        run: dpkg -l
+      - name: Format code
+        run: cmake -P CMake/Format.cmake
 
-      # - name: Install codespell and cmake-format
-      #   run: pip install codespell cmakelang
-
-      # - name: Print versions
-      #   run: |
-      #     python --version
-      #     pip --version
-      #     cmake --version
-      #     clang-format --version
-      #     cmake-format --version
-      #     codespell --version
-
-      # - name: Format code
-      #   run: cmake -P CMake/Format.cmake
-
-      # - name: Spell check
-      #   run: cmake -P CMake/Spell.cmake
+      - name: Spell check
+        run: cmake -P CMake/Spell.cmake
 
   test-windows:
-    if: false
     needs: format-and-spell
     runs-on: windows-2022
     steps:
@@ -107,66 +83,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Install LLVM ${{ env.LLVM_VERSION }}
-      #   uses: aminya/setup-cpp@v1
-      #   with:
-      #     compiler: llvm-${{ env.LLVM_VERSION }}
+      - name: Install tools
+        run: |
+          sudo apt update -q
+          sudo apt install -y cppcheck ninja valgrind
+          pip install gcovr
 
-      # - name: Install GCC ${{ env.GCC_VERSION }}
-      #   uses: aminya/setup-cpp@v1
-      #   with:
-      #     compiler: gcc-${{ env.GCC_VERSION }}
-
-      # Ubuntu 24.04 comes with GCC 12, 13 and 14 as well as Clang 12, 13 and 14. Let's see what the
-      # default versions are.
-      - name: Print versions
+      - name: Print and store version info
+        shell: pwsh
         run: |
           g++ --version
           clang++ --version
           clang-tidy --version
-          clang-format --verison
-          g++-13 --version
-          clang++-18 --version
-          clang-tidy-18 --version
-          clang-format-18 --version
-
-      - name: Install tools
-        uses: aminya/setup-cpp@v1
-        with:
-          cmake: ${{ env.CMAKE_VERSION }}
-          ninja: ${{ env.NINJA_VERSION }}
-          clangtidy: ${{ env.LLVM_VERSION }}
-          cppcheck: true
-          gcovr: 7
-
-      - name: Install Include What You Use
-        run: |
-          git clone --depth 1 --branch clang_${{ env.LLVM_VERSION }} https://github.com/include-what-you-use/include-what-you-use.git
-          cd include-what-you-use
-          cmake -B build -S . -G Ninja -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${{ env.LLVM_VERSION }}
-          cmake --build build
-          sudo cmake --install build
-
-      - name: Install Valgrind and store version info
-        run: |
-          sudo apt-get install -y valgrind
-          export VALGRIND_VERSION=$(valgrind --version | sed -r 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-          echo "VALGRIND_MAJOR_VERSION=$(echo $VALGRIND_VERSION | cut -d '.' -f 1)" >> $GITHUB_ENV
-          echo "VALGRIND_MINOR_VERSION=$(echo $VALGRIND_VERSION | cut -d '.' -f 2)" >> $GITHUB_ENV
-
-      - name: Print versions of compilers and tools
-        run: |
-          g++ --version
-          clang++ --version
           cmake --version
           ninja --version
-          clang-tidy --version
           cppcheck --version
           gcovr --version
           gcov --version
-          gcov-${{ env.GCC_VERSION }} --version || true
           llvm-cov --version
           valgrind --version
+
+          $CLANG_VERSIONS = (clang++ --version | Select-String -Pattern '([0-9]+)\.([0-9]+)\.([0-9]+)').Matches.Groups.Value
+          "CLANG_MAJOR_VERSION=$CLANG_VERSIONS[1]" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+          $VALGRIND_VERSIONS = (valgrind --version | Select-String -Pattern '([0-9]+)\.([0-9]+)\.([0-9]+)').Matches.Groups.Value
+          "VALGRIND_MAJOR_VERSION=$VALGRIND_VERSIONS[1]" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "VALGRIND_MINOR_VERSION=$VALGRIND_VERSIONS[2]" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install Include What You Use
+        run: |
+          git clone --depth 1 --branch clang_${{ env.CLANG_MAJOR_VERSION }} https://github.com/include-what-you-use/include-what-you-use.git
+          cd include-what-you-use
+          cmake -B build -S . -G Ninja -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${{ env.CLANG_MAJOR_VERSION }}
+          cmake --build build
+          sudo cmake --install build
 
       - name: Set up vcpkg
         id: set-up-vcpkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,20 @@ jobs:
         with:
           compiler: gcc-${{ env.GCC_VERSION }}
 
-      - name: Install LLVM ${{ env.LLVM_VERSION }} and tools
+      - name: Install LLVM ${{ env.LLVM_VERSION }}
         uses: aminya/setup-cpp@v1
         with:
           compiler: llvm-${{ env.LLVM_VERSION }}
+
+      - name: Print versions
+        run: |
+          g++ --version
+          clang++ --version
+          clang-tidy --version || true
+
+      - name: Install tools
+        uses: aminya/setup-cpp@v1
+        with:
           cmake: ${{ env.CMAKE_VERSION }}
           ninja: ${{ env.NINJA_VERSION }}
           clangtidy: ${{ env.LLVM_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
         run: cmake --workflow --preset ci-windows-clang-cl
 
   test-ubuntu:
-    if: false
     needs: format-and-spell
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
 
       - name: Install tools
         run: |
-          sudo apt update -q
-          sudo apt install -y cppcheck ninja valgrind
+          sudo apt-get update -q
+          sudo apt-get install -y cppcheck ninja-build valgrind
           pipx install gcovr
 
       - name: Print and store version info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  LLVM_VERSION: '18.1.8'
+  LLVM_VERSION: '18.1.7'
   GCC_VERSION: '13'
   CMAKE_VERSION: '3.30.1'
   NINJA_VERSION: '1.10.1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           clang-tidy-18 --version
           clang-format-18 --version
 
+      - name: Print installed apt packages
+        run: dpkg -l
+
       # - name: Install codespell and cmake-format
       #   run: pip install codespell cmakelang
 
@@ -54,7 +57,7 @@ jobs:
       #   run: cmake -P CMake/Format.cmake
 
       # - name: Spell check
-        run: cmake -P CMake/Spell.cmake
+      #   run: cmake -P CMake/Spell.cmake
 
   test-windows:
     if: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install tools
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y cppcheck ninja-build valgrind
+          sudo apt-get install -y cppcheck ninja-build valgrind llvm
           pipx install gcovr
 
       - name: Print and store version info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,15 +91,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install GCC ${{ env.GCC_VERSION }}
-        uses: aminya/setup-cpp@v1
-        with:
-          compiler: gcc-${{ env.GCC_VERSION }}
-
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         uses: aminya/setup-cpp@v1
         with:
           compiler: llvm-${{ env.LLVM_VERSION }}
+
+      - name: Install GCC ${{ env.GCC_VERSION }}
+        uses: aminya/setup-cpp@v1
+        with:
+          compiler: gcc-${{ env.GCC_VERSION }}
 
       - name: Print versions
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,9 @@ jobs:
         run: |
           g++ --version
           clang++ --version
-          clang-tidy --version
           cmake --version
           ninja --version
+          clang-tidy --version
           cppcheck --version
           gcovr --version
           gcov --version
@@ -104,10 +104,6 @@ jobs:
 
           $CLANG_VERSIONS = (clang++ --version | Select-String -Pattern '([0-9]+)\.([0-9]+)\.([0-9]+)').Matches.Groups.Value
           "CLANG_MAJOR_VERSION=$($CLANG_VERSIONS[1])" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-          $VALGRIND_VERSIONS = (valgrind --version | Select-String -Pattern '([0-9]+)\.([0-9]+)\.([0-9]+)').Matches.Groups.Value
-          "VALGRIND_MAJOR_VERSION=$($VALGRIND_VERSIONS[1])" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "VALGRIND_MINOR_VERSION=$($VALGRIND_VERSIONS[2])" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Include What You Use
         run: |
@@ -193,9 +189,8 @@ jobs:
 
       - name: Build and test debug and release mode with Valgrind (Clang)
         # Running tests with Valgrind is slow, so we only do it if running them with sanitizers
-        # succeeded. Also, at least Valgrind 3.20 is required because Clang >= 14 generates DWARF 5
-        # code by default, which is not supported by older versions of Valgrind.
-        if: ${{ !cancelled() && steps.sanitize-clang.conclusion == 'success' && env.VALGRIND_MAJOR_VERSION >= 3 && env.VALGRIND_MINOR_VERSION >= 20 }}
+        # succeeded.
+        if: ${{ !cancelled() && steps.sanitize-clang.conclusion == 'success' }}
         run: |
           export CXX=clang++
           cmake --workflow --preset ci-valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Install Include What You Use
         run: |
+          sudo apt-get install -y llvm-${{ env.CLANG_MAJOR_VERSION }}-dev libclang-${{ env.CLANG_MAJOR_VERSION }}-dev
           git clone --depth 1 --branch clang_${{ env.CLANG_MAJOR_VERSION }} https://github.com/include-what-you-use/include-what-you-use.git
           cd include-what-you-use
           cmake -B build -S . -G Ninja -DCMAKE_PREFIX_PATH=/usr/lib/llvm-${{ env.CLANG_MAJOR_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  LLVM_VERSION: '18.1.7'
+  # LLVM_VERSION: '18.1.7'
   GCC_VERSION: '13'
   CMAKE_VERSION: '3.30.1'
   NINJA_VERSION: '1.10.1'
@@ -18,34 +18,46 @@ env:
 
 jobs:
   format-and-spell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up clang-format
-        uses: aminya/setup-cpp@v1
-        with:
-          clangformat: ${{ env.LLVM_VERSION }}
-
-      - name: Install codespell and cmake-format
-        run: pip install codespell cmakelang
+      # - name: Set up clang-format
+      #   uses: aminya/setup-cpp@v1
+      #   with:
+      #     clangformat: ${{ env.LLVM_VERSION }}
 
       - name: Print versions
         run: |
-          python --version
-          pip --version
-          cmake --version
-          clang-format --version
-          cmake-format --version
-          codespell --version
+          g++ --version
+          clang++ --version
+          clang-tidy --version
+          clang-format --verison
+          g++-13 --version
+          clang++-18 --version
+          clang-tidy-18 --version
+          clang-format-18 --version
 
-      - name: Format code
-        run: cmake -P CMake/Format.cmake
+      # - name: Install codespell and cmake-format
+      #   run: pip install codespell cmakelang
 
-      - name: Spell check
+      # - name: Print versions
+      #   run: |
+      #     python --version
+      #     pip --version
+      #     cmake --version
+      #     clang-format --version
+      #     cmake-format --version
+      #     codespell --version
+
+      # - name: Format code
+      #   run: cmake -P CMake/Format.cmake
+
+      # - name: Spell check
         run: cmake -P CMake/Spell.cmake
 
   test-windows:
+    if: false
     needs: format-and-spell
     runs-on: windows-2022
     steps:
@@ -86,8 +98,9 @@ jobs:
         run: cmake --workflow --preset ci-windows-clang-cl
 
   test-ubuntu:
+    if: false
     needs: format-and-spell
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install codespell and cmake-format
-        run: pip install codespell cmakelang
-
       - name: Print versions
         run: |
-          python --version
+          python --version || true
+          python3 --version || true
           pip --version
           cmake --version
           clang-format --version
+
+      - name: Install codespell and cmake-format
+        run: python -m pip install codespell cmakelang
+
+      - name: Print versions
+        run: |
           cmake-format --version
           codespell --version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,19 +18,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install codespell and cmake-format
+        run: pipx install codespell cmakelang
+
       - name: Print versions
         run: |
-          python --version || true
-          python3 --version || true
-          pip --version
+          python --version
+          pipx --version
           cmake --version
           clang-format --version
-
-      - name: Install codespell and cmake-format
-        run: python -m pip install codespell cmakelang
-
-      - name: Print versions
-        run: |
           cmake-format --version
           codespell --version
 
@@ -91,7 +87,7 @@ jobs:
         run: |
           sudo apt update -q
           sudo apt install -y cppcheck ninja valgrind
-          pip install gcovr
+          pipx install gcovr
 
       - name: Print and store version info
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,11 @@ jobs:
           valgrind --version
 
           $CLANG_VERSIONS = (clang++ --version | Select-String -Pattern '([0-9]+)\.([0-9]+)\.([0-9]+)').Matches.Groups.Value
-          "CLANG_MAJOR_VERSION=$CLANG_VERSIONS[1]" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "CLANG_MAJOR_VERSION=$($CLANG_VERSIONS[1])" | Out-File -FilePath $env:GITHUB_ENV -Append
 
           $VALGRIND_VERSIONS = (valgrind --version | Select-String -Pattern '([0-9]+)\.([0-9]+)\.([0-9]+)').Matches.Groups.Value
-          "VALGRIND_MAJOR_VERSION=$VALGRIND_VERSIONS[1]" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "VALGRIND_MINOR_VERSION=$VALGRIND_VERSIONS[2]" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "VALGRIND_MAJOR_VERSION=$($VALGRIND_VERSIONS[1])" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "VALGRIND_MINOR_VERSION=$($VALGRIND_VERSIONS[2])" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Install Include What You Use
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           g++ --version
           clang++ --version
           clang-tidy --version
-          clang-format --verison
+          clang-format --version
           g++-13 --version
           clang++-18 --version
           clang-tidy-18 --version
@@ -107,21 +107,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install LLVM ${{ env.LLVM_VERSION }}
-        uses: aminya/setup-cpp@v1
-        with:
-          compiler: llvm-${{ env.LLVM_VERSION }}
+      # - name: Install LLVM ${{ env.LLVM_VERSION }}
+      #   uses: aminya/setup-cpp@v1
+      #   with:
+      #     compiler: llvm-${{ env.LLVM_VERSION }}
 
-      - name: Install GCC ${{ env.GCC_VERSION }}
-        uses: aminya/setup-cpp@v1
-        with:
-          compiler: gcc-${{ env.GCC_VERSION }}
+      # - name: Install GCC ${{ env.GCC_VERSION }}
+      #   uses: aminya/setup-cpp@v1
+      #   with:
+      #     compiler: gcc-${{ env.GCC_VERSION }}
 
+      # Ubuntu 24.04 comes with GCC 12, 13 and 14 as well as Clang 12, 13 and 14. Let's see what the
+      # default versions are.
       - name: Print versions
         run: |
           g++ --version
           clang++ --version
-          clang-tidy --version || true
+          clang-tidy --version
+          clang-format --verison
+          g++-13 --version
+          clang++-18 --version
+          clang-tidy-18 --version
+          clang-format-18 --version
 
       - name: Install tools
         uses: aminya/setup-cpp@v1


### PR DESCRIPTION
This fixes the issues with installing LLVM 18 because the ubuntu-24.04 image already comes preinstalled with that. It also comes with many other more up-to-date tools like GCC 13, CMake 3.30, or Valgrind 3.22, which makes installing dependencies much easier and faster.

Fixes #32 