### PR TITLE
Downgrade required CMake version to 3.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - main
 
 env:
+  CMAKE_VERSION: '3.29.6'
   VCPKG_COMMITTISH: 49ac2134b31b95b0ddf29d56873dcd24392691df
 
 jobs:
@@ -47,7 +48,7 @@ jobs:
         with:
           vcvarsall: true
           cmake: ${{ env.CMAKE_VERSION }}
-          ninja: ${{ env.NINJA_VERSION }}
+          ninja: true
 
       - name: Print version of build tools
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.29)
 
 include(CMake/Prelude.cmake)
 


### PR DESCRIPTION
For some reason 3.30 is not available via apt.kitware.com for Ubuntu 22.04. Since this is the Ubuntu version that runs on the Bullseye PC and that I use in WSL this is a highly inconvenient.