### PR TITLE
Fix `ci-valgrind` workflow not running Valgrind in release mode

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -349,7 +349,7 @@
         },
         {
           "type": "build",
-          "name": "ci-ubuntu-debug-valgrind"
+          "name": "ci-ubuntu-release-valgrind"
         }
       ]
     },


### PR DESCRIPTION
Fixes #42

This PR replaces #44 because I didn't rebase before merging there.