### PR TITLE
Turn IWYU warnings into errors and add mappings for NamedType

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,11 @@ jobs:
         run: |
           git config --global credential.https://github.com/fantana21.helper '!f() { echo username=QuantNd; echo password=${{ secrets.ALL_REPOSITORIES_PAT }}; }; f'
 
+      - name: Build with Include What You Use
+        run: |
+          export CXX=g++
+          cmake --workflow --preset ci-include-what-you-use
+
       - name: Build and test debug and release mode (GCC)
         id: test-gcc
         run: |
@@ -168,12 +173,6 @@ jobs:
         run: |
           export CXX=g++
           cmake --workflow --preset ci-valgrind
-
-      - name: Build with Include What You Use
-        if: ${{ !cancelled() && steps.valgrind-gcc.conclusion == 'success' }}
-        run: |
-          export CXX=g++
-          cmake --workflow --preset ci-include-what-you-use
 
       - name: Build and test debug and release mode (Clang)
         id: test-clang

--- a/CMakeDeveloperPresets.json
+++ b/CMakeDeveloperPresets.json
@@ -112,6 +112,10 @@
       "configuration": "Release"
     },
     {
+      "name": "dev-linux-iwyu",
+      "configurePreset": "dev-linux-iwyu"
+    },
+    {
       "name": "dev-linux-coverage",
       "configurePreset": "dev-linux-coverage"
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,7 @@
       "name": "include-what-you-use",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_INCLUDE_WHAT_YOU_USE": "include-what-you-use;-Xiwyu;--error"
+        "CMAKE_CXX_INCLUDE_WHAT_YOU_USE": "include-what-you-use;-Xiwyu;--error;-Xiwyu;--mapping_file=${sourceDir}/iwyu.imp"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,7 @@
       "name": "include-what-you-use",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_INCLUDE_WHAT_YOU_USE": "include-what-you-use"
+        "CMAKE_CXX_INCLUDE_WHAT_YOU_USE": "include-what-you-use;-Xiwyu;--error"
       }
     },
     {

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -1,0 +1,4 @@
+[
+    # Only use NamedType's facade header
+    { include: ["@<NamedType/.*>", "private", "<NamedType/named_type.hpp>", "public"] },
+]


### PR DESCRIPTION
I am against turning compiler warnings into errors, because sometimes there is a good reason to temporarily introduce warnings. I cannot think of such good reasons for IWYU warnings, though. The includes must always be correct. With mapping files and the IWYU pragmas it is also very simple to fix false warnings.

I also moved the IWYU job step up, so that the workflow can fail earlier because of include errors.

Fixes #43 