### PR TITLE
Upgrade to GCC 14, Clang 19, CMake 3.31, and C++23

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,23 +1,23 @@
 ---
-# For clang-format 18
-Language:        Cpp
+# For clang-format 19
+Language: Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: Right
+AlignArrayOfStructures: Left
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: Consecutive
 AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: false
 AlignConsecutiveShortCaseStatements:
-  Enabled:         false
+  Enabled:          false
   AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCaseColons: false
+  AcrossComments:   false
+  AlignCaseColons:  false
 AlignEscapedNewlines: DontAlign
-AlignOperands:   AlignAfterOperator
+AlignOperands: AlignAfterOperator
 AlignTrailingComments:
-  Kind:            Always
-  OverEmptyLines:  0
+  Kind:           Always
+  OverEmptyLines: 0
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowBreakBeforeNoexceptSpecifier: OnlyWithParen
@@ -33,51 +33,53 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - ''
 BinPackArguments: false
 BinPackParameters: false
 BitFieldColonSpacing: Both
 BraceWrapping:
-  AfterCaseLabel:  true
-  AfterClass:      true
+  AfterCaseLabel:        true
+  AfterClass:            true
   AfterControlStatement: Always
-  AfterEnum:       true
-  AfterExternBlock: true
-  AfterFunction:   true
-  AfterNamespace:  true
-  AfterObjCDeclaration: true
-  AfterStruct:     true
-  AfterUnion:      true
-  BeforeCatch:     true
-  BeforeElse:      true
-  BeforeLambdaBody: true
-  BeforeWhile:     false
-  IndentBraces:    false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-  SplitEmptyNamespace: false
+  AfterEnum:             true
+  AfterExternBlock:      true
+  AfterFunction:         true
+  AfterNamespace:        true
+  AfterObjCDeclaration:  true
+  AfterStruct:           true
+  AfterUnion:            true
+  BeforeCatch:           true
+  BeforeElse:            true
+  BeforeLambdaBody:      true
+  BeforeWhile:           false
+  IndentBraces:          false
+  SplitEmptyFunction:    false
+  SplitEmptyRecord:      false
+  SplitEmptyNamespace:   false
 BreakAdjacentStringLiterals: true
 BreakAfterAttributes: Never
 BreakAfterJavaFieldAnnotations: true
-BreakArrays:     false
+BreakAfterReturnType: Automatic
+BreakArrays: false
 BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Custom
 BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
+BreakFunctionDefinitionParameters: false
 BreakInheritanceList: AfterComma
 BreakStringLiterals: true
-ColumnLimit:     100
-CommentPragmas:  '^ IWYU pragma:'
+BreakTemplateDeclarations: Yes
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
@@ -87,37 +89,25 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
 IfMacros: []
-IncludeBlocks:   Regroup
+IncludeBlocks: Regroup
 IncludeCategories:
   # Parsing is done in the order defined here, so this is not ordered by priority but specificity of
   # the regex. The main header for a source file is automatically assigned priority 0.
+  #
   # C stdandard library
-  - Regex:           '^<(assert|complex|ctype|ctype|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdatomic|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>'
-    Priority:        7
-    SortPriority:    0
-    CaseSensitive:   false
+  - Regex: '^<(assert|complex|ctype|ctype|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdatomic|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>'
+    Priority: 4
   # C++ stdandard library: <*> without a dot
-  - Regex:           '^<[a-z_]+>'
-    Priority:        6
-    SortPriority:    0
-    CaseSensitive:   false
+  - Regex: '^<[a-z_]+>'
+    Priority: 3
   # CppProjectTemplate header files <CppProjectTemplate/*.hpp> without underscores
-  - Regex:           '^<CppProjectTemplate(\/[A-Za-z0-9]+)+\.hpp>'
-    Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
-  # C headers from external libraries: <**/*.h>
-  - Regex:           '^<([A-Za-z0-9_-]+\/)*[A-Za-z0-9_-]+\.h>'
-    Priority:        3
-    SortPriority:    0
-    CaseSensitive:   false
-  # C++ headers from external libraries: <**/*.hh> or <**/*.hpp> or <**/*.h++>
-  - Regex:           '^<([A-Za-z0-9_-]+\/)*[A-Za-z0-9_-]+\.h(h|pp|\+\+)>'
-    Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-IncludeIsMainRegex: '(.test)?$'
-IncludeIsMainSourceRegex: ''
+  - Regex: '^<CppProjectTemplate(\/[A-Za-z0-9]+)+\.hpp>'
+    Priority: 1
+  # C and C++ headers from external libraries: <**/*.(h|hh|hpp|h++)>
+  - Regex: '^<([A-Za-z0-9_-]+\/)*[A-Za-z0-9_-]+\.(h|hh|hpp|h\+\+)>'
+    Priority: 2
+IncludeIsMainRegex: '$'
+IncludeIsMainSourceRegex: '(\.ipp)$'
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: true
@@ -125,26 +115,29 @@ IndentExternBlock: NoIndent
 IndentGotoLabels: true
 IndentPPDirectives: BeforeHash
 IndentRequiresClause: true
-IndentWidth:     4
+IndentWidth: 4
 IndentWrappedFunctionNames: false
-InsertBraces:    true
+InsertBraces: true
 InsertNewlineAtEOF: true
 InsertTrailingCommas: Wrapped
 IntegerLiteralSeparator:
-  Binary:          4
-  BinaryMinDigits: 5
-  Decimal:         3
-  DecimalMinDigits: 4
-  Hex:             4
-  HexMinDigits:    5
+  Binary:           4
+  BinaryMinDigits:  5
+  Decimal:          3
+  DecimalMinDigits: 5
+  Hex:              4
+  HexMinDigits:     5
 JavaScriptQuotes: Double
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-KeepEmptyLinesAtEOF: false
+KeepEmptyLines:
+  AtEndOfFile: false
+  AtStartOfBlock: false
+  AtStartOfFile: false
 LambdaBodyIndentation: Signature
-LineEnding:      DeriveLF
+LineEnding: DeriveLF
 MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockEnd: ''
+MainIncludeChar: AngleBracket
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
@@ -165,7 +158,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Middle
-PPIndentWidth:   -1
+PPIndentWidth: -1
 QualifierAlignment: Custom
 QualifierOrder:
   - static
@@ -175,7 +168,7 @@ QualifierOrder:
   - const
   - volatile
 RawStringFormats:
-  - Language:        Cpp
+  - Language: Cpp
     Delimiters:
       - cc
       - CC
@@ -185,8 +178,8 @@ RawStringFormats:
       - 'c++'
       - 'C++'
     CanonicalDelimiter: ''
-    BasedOnStyle:    microsoft
-  - Language:        TextProto
+    BasedOnStyle: microsoft
+  - Language: TextProto
     Delimiters:
       - pb
       - PB
@@ -203,9 +196,9 @@ RawStringFormats:
       - ParseTestProto
       - ParsePartialTestProto
     CanonicalDelimiter: ''
-    BasedOnStyle:    google
+    BasedOnStyle: google
 ReferenceAlignment: Pointer
-ReflowComments:  true
+ReflowComments: true
 RemoveBracesLLVM: false
 RemoveParentheses: Leave
 RemoveSemicolon: false
@@ -215,7 +208,7 @@ RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SkipMacroDefinitionBody: false
-SortIncludes:    CaseInsensitive
+SortIncludes: CaseInsensitive
 SortJavaStaticImport: Before
 SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
@@ -230,40 +223,40 @@ SpaceBeforeInheritanceColon: true
 SpaceBeforeJsonColon: false
 SpaceBeforeParens: Custom
 SpaceBeforeParensOptions:
-  AfterControlStatements: false
-  AfterForeachMacros: false
-  AfterFunctionDefinitionName: false
+  AfterControlStatements:       false
+  AfterForeachMacros:           false
+  AfterFunctionDefinitionName:  false
   AfterFunctionDeclarationName: false
-  AfterIfMacros:   false
-  AfterOverloadedOperator: false
-  AfterPlacementOperator: false
-  AfterRequiresInClause: false
-  AfterRequiresInExpression: false
-  BeforeNonEmptyParentheses: false
+  AfterIfMacros:                false
+  AfterOverloadedOperator:      false
+  AfterPlacementOperator:       false
+  AfterRequiresInClause:        false
+  AfterRequiresInExpression:    false
+  BeforeNonEmptyParentheses:    false
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles:  Never
+SpacesInAngles: Never
 SpacesInContainerLiterals: false
 SpacesInLineCommentPrefix:
-  Minimum:         1
-  Maximum:         -1
-SpacesInParens:  Never
+  Minimum:  1
+  Maximum: -1
+SpacesInParens: Never
 SpacesInParensOptions:
-  InCStyleCasts:   false
+  InCStyleCasts:           false
   InConditionalStatements: false
-  InEmptyParentheses: false
-  Other:           false
+  InEmptyParentheses:      false
+  Other:                   false
 SpacesInSquareBrackets: false
-Standard:        Auto
+Standard: Auto
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-TabWidth:        4
-UseTab:          Never
+TabWidth: 4
+UseTab: Never
 VerilogBreakBetweenInstancePorts: true
 WhitespaceSensitiveMacros:
   - STRINGIZE

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,39 +1,253 @@
 ---
-# Enable ALL the things! Except not really. We don't use the abseil library, OpenCL (the altera
-# stuff), android, darwin (an Apple OS apparently), MPI or OpenMP. The fuchsia checks are just too
-# restrictive, we don't write Objective-C and don't develop the Linux kernel or LLVM-libc.
-# misc-non-private-member-variables-in-classes: the options don't do anything.
-# misc-const-correctness is not about const-correctness, but about const-ness of local variables and
-# I am not on the const-all-the-things bandwagon.
+# For clang-tidy 19
+#
+# Enable all the things! Except not really. We don't use/develop for
+#
+# - Abseil library
+# - Altera (OpenCL programming for FPGAs)
+# - Android
+# - Boost
+# - Darwin (Apple platforms)
+# - Fuchisa (but the inheritance checks are use)
+# - Google Test
+# - Objective-C (google-objc)
+# - Linux kernel
+# - LLVM
+# - LLVM-libc
+# - MPI
+# - OpenMP
+#
+# We also disable some specific checks that we don't like:
+#
+# - avoid-c-arrays: C arrays are fine if used only locally.
+# - bugprone-implicit-widening-of-multiplication-result: I am not sure anymore but I think this is
+#   too noisy.
+# - clang-analyzer-cplusplus.NewDeleteLeaks: I don't know how to silence potential false positives
+#   that it found in doctest.h, so I disable it completely. Also, we have Valgrind anyway.
+# - clang-diagnostic-unused-command-line-argument: I don't remember why I disabled this, but it
+#   doesn't sound like an important check.
+# - google-readability-todo: We don't require names and/or bug numbers in TODO comments.
+# - google-runtime-int: We don't require using std::int32_t, etc. instead of int, long, ...
+# - misc-const-correctness: It's not about const-correctness, but about const-ness of local
+#   variables and I am not on the const-all-the-things bandwagon.
+# - misc-header-include-cycle: Triggers in our .ipp files. For some reason I can't disable the
+#   warnings with NOLINT comments and the IgnoredFilesList option is too cumbersome to use.
+# - modernize-use-designated-initializers: This is too verbose since we try to use different strong
+#   types for every field.
+# - namespace-comment: We don't use namespace comments.
+# - performance-enum-size: The added noise outweighs the potential performance gains of reduced enum
+#   sizes in desktop applications. For embedded systems, this check should be enabled.
+# - readability-math-missing-parentheses: We are not that stupid.
+# - readability-static-accessed-through-instance: Accessing a static member through an instance is
+#   too convenient to give up.
+#
+# The rest are all alias checks according to the documentation of clang-tidy 19.1.0. Apparently,
+# they run like normal checks, so they do unnecessary duplicate work.
 Checks: "*,\
-  -*avoid-c-arrays,\
   -abseil-*,\
-  -altera-id-dependent-backward-branch,\
-  -altera-kernel-name-restriction,\
-  -altera-single-work-item-barrier,\
-  -altera-struct-pack-align,\
-  -altera-unroll-loops,\
+  -altera-*,\
   -android-*,\
-  -bugprone-implicit-widening-of-multiplication-result,\
-  -clang-diagnostic-unused-command-line-argument,\
+  -boost-*,\
   -darwin-*,\
   -fuchsia-*,\
-  fuchsia-multiple-inheritance,\
+  -*googletest*,\
   -google-objc-*,\
-  -google-readability-namespace-comments,\
+  -linuxkernel-*,\
+  -llvm-*,\
+  -llvmlibc-*,\
+  -mpi-*,\
+  -openmp-*,\
+  -*avoid-c-arrays,\
+  -bugprone-implicit-widening-of-multiplication-result,\
+  -clang-analyzer-cplusplus.NewDeleteLeaks,\
+  -clang-diagnostic-unused-command-line-argument,\
+  fuchsia-multiple-inheritance,\
+  fuchsia-virtual-inheritance,\
   -google-readability-todo,\
   -google-runtime-int,\
-  -linuxkernel-must-use-errs,\
-  -llvm-header-guard,\
-  -llvm-namespace-comment,\
-  -llvmlibc-*,\
   -misc-const-correctness,\
-  -mpi-*,\
-  -openmp-*"
+  -misc-header-include-cycle,\
+  -modernize-use-designated-initializers,\
+  -*namespace-comment*,\
+  -performance-enum-size,\
+  -readability-math-missing-parentheses,\
+  -readability-static-accessed-through-instance,\
+  -bugprone-narrowing-conversions,\
+  -cert-con36-c,\
+  -cert-con54-cpp,\
+  -cert-ctr56-cpp,\
+  -cert-dcl03-c,\
+  -cert-dcl16-c,\
+  -cert-dcl37-c,\
+  -cert-dcl51-cpp,\
+  -cert-dcl54-cpp,\
+  -cert-dcl59-cpp,\
+  -cert-err09-cpp,\
+  -cert-err61-cpp,\
+  -cert-exp42-c,\
+  -cert-fio38-c,\
+  -cert-flp37-c,\
+  -cert-int09-c,\
+  -cert-msc24-c,\
+  -cert-msc30-c,\
+  -cert-msc32-c,\
+  -cert-msc33-c,\
+  -cert-msc54-cpp,\
+  -cert-oop11-cpp,\
+  -cert-oop54-cpp,\
+  -cert-pos44-c,\
+  -cert-pos47-c,\
+  -cert-sig30-c,\
+  -cert-str34-c,\
+  -clang-analyzer-core.BitwiseShift,\
+  -clang-analyzer-core.CallAndMessage,\
+  -clang-analyzer-core.DivideZero,\
+  -clang-analyzer-core.NonNullParamChecker,\
+  -clang-analyzer-core.NullDereference,\
+  -clang-analyzer-core.StackAddressEscape,\
+  -clang-analyzer-core.UndefinedBinaryOperatorResult,\
+  -clang-analyzer-core.VLASize,\
+  -clang-analyzer-core.uninitialized.ArraySubscript,\
+  -clang-analyzer-core.uninitialized.Assign,\
+  -clang-analyzer-core.uninitialized.Branch,\
+  -clang-analyzer-core.uninitialized.CapturedBlockVariable,\
+  -clang-analyzer-core.uninitialized.NewArraySize,\
+  -clang-analyzer-core.uninitialized.UndefReturn,\
+  -clang-analyzer-cplusplus.ArrayDelete,\
+  -clang-analyzer-cplusplus.InnerPointer,\
+  -clang-analyzer-cplusplus.Move,\
+  -clang-analyzer-cplusplus.NewDelete,\
+  -clang-analyzer-cplusplus.NewDeleteLeaks,\
+  -clang-analyzer-cplusplus.PlacementNew,\
+  -clang-analyzer-cplusplus.PureVirtualCall,\
+  -clang-analyzer-cplusplus.StringChecker,\
+  -clang-analyzer-deadcode.DeadStores,\
+  -clang-analyzer-fuchsia.HandleChecker,\
+  -clang-analyzer-nullability.NullPassedToNonnull,\
+  -clang-analyzer-nullability.NullReturnedFromNonnull,\
+  -clang-analyzer-nullability.NullableDereferenced,\
+  -clang-analyzer-nullability.NullablePassedToNonnull,\
+  -clang-analyzer-nullability.NullableReturnedFromNonnull,\
+  -clang-analyzer-optin.core.EnumCastOutOfRange,\
+  -clang-analyzer-optin.cplusplus.UninitializedObject,\
+  -clang-analyzer-optin.cplusplus.VirtualCall,\
+  -clang-analyzer-optin.mpi.MPI-Checker,\
+  -clang-analyzer-optin.osx.OSObjectCStyleCast,\
+  -clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker,\
+  -clang-analyzer-optin.osx.cocoa.localizability.NonLocalizedStringChecker,\
+  -clang-analyzer-optin.performance.GCDAntipattern,\
+  -clang-analyzer-optin.performance.Padding,\
+  -clang-analyzer-optin.portability.UnixAPI,\
+  -clang-analyzer-optin.taint.TaintedAlloc,\
+  -clang-analyzer-osx.API,\
+  -clang-analyzer-osx.MIG,\
+  -clang-analyzer-osx.NumberObjectConversion,\
+  -clang-analyzer-osx.OSObjectRetainCount,\
+  -clang-analyzer-osx.ObjCProperty,\
+  -clang-analyzer-osx.SecKeychainAPI,\
+  -clang-analyzer-osx.cocoa.AtSync,\
+  -clang-analyzer-osx.cocoa.AutoreleaseWrite,\
+  -clang-analyzer-osx.cocoa.ClassRelease,\
+  -clang-analyzer-osx.cocoa.Dealloc,\
+  -clang-analyzer-osx.cocoa.IncompatibleMethodTypes,\
+  -clang-analyzer-osx.cocoa.Loops,\
+  -clang-analyzer-osx.cocoa.MissingSuperCall,\
+  -clang-analyzer-osx.cocoa.NSAutoreleasePool,\
+  -clang-analyzer-osx.cocoa.NSError,\
+  -clang-analyzer-osx.cocoa.NilArg,\
+  -clang-analyzer-osx.cocoa.NonNilReturnValue,\
+  -clang-analyzer-osx.cocoa.ObjCGenerics,\
+  -clang-analyzer-osx.cocoa.RetainCount,\
+  -clang-analyzer-osx.cocoa.RunLoopAutoreleaseLeak,\
+  -clang-analyzer-osx.cocoa.SelfInit,\
+  -clang-analyzer-osx.cocoa.SuperDealloc,\
+  -clang-analyzer-osx.cocoa.UnusedIvars,\
+  -clang-analyzer-osx.cocoa.VariadicMethodTypes,\
+  -clang-analyzer-osx.coreFoundation.CFError,\
+  -clang-analyzer-osx.coreFoundation.CFNumber,\
+  -clang-analyzer-osx.coreFoundation.CFRetainRelease,\
+  -clang-analyzer-osx.coreFoundation.containers.OutOfBounds,\
+  -clang-analyzer-osx.coreFoundation.containers.PointerSizedValues,\
+  -clang-analyzer-security.FloatLoopCounter,\
+  -clang-analyzer-security.PutenvStackArray,\
+  -clang-analyzer-security.SetgidSetuidOrder,\
+  -clang-analyzer-security.cert.env.InvalidPtr,\
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,\
+  -clang-analyzer-security.insecureAPI.UncheckedReturn,\
+  -clang-analyzer-security.insecureAPI.bcmp,\
+  -clang-analyzer-security.insecureAPI.bcopy,\
+  -clang-analyzer-security.insecureAPI.bzero,\
+  -clang-analyzer-security.insecureAPI.decodeValueOfObjCType,\
+  -clang-analyzer-security.insecureAPI.getpw,\
+  -clang-analyzer-security.insecureAPI.gets,\
+  -clang-analyzer-security.insecureAPI.mkstemp,\
+  -clang-analyzer-security.insecureAPI.mktemp,\
+  -clang-analyzer-security.insecureAPI.rand,\
+  -clang-analyzer-security.insecureAPI.strcpy,\
+  -clang-analyzer-security.insecureAPI.vfork,\
+  -clang-analyzer-unix.API,\
+  -clang-analyzer-unix.BlockInCriticalSection,\
+  -clang-analyzer-unix.Errno,\
+  -clang-analyzer-unix.Malloc,\
+  -clang-analyzer-unix.MallocSizeof,\
+  -clang-analyzer-unix.MismatchedDeallocator,\
+  -clang-analyzer-unix.StdCLibraryFunctions,\
+  -clang-analyzer-unix.Stream,\
+  -clang-analyzer-unix.Vfork,\
+  -clang-analyzer-unix.cstring.BadSizeArg,\
+  -clang-analyzer-unix.cstring.NullArg,\
+  -clang-analyzer-valist.CopyToSelf,\
+  -clang-analyzer-valist.Uninitialized,\
+  -clang-analyzer-valist.Unterminated,\
+  -clang-analyzer-webkit.NoUncountedMemberChecker,\
+  -clang-analyzer-webkit.RefCntblBaseVirtualDtor,\
+  -clang-analyzer-webkit.UncountedLambdaCapturesChecker,\
+  -cppcoreguidelines-avoid-c-arrays,\
+  -cppcoreguidelines-avoid-magic-numbers,\
+  -cppcoreguidelines-c-copy-assignment-signature,\
+  -cppcoreguidelines-explicit-virtual-functions,\
+  -cppcoreguidelines-macro-to-enum,\
+  -cppcoreguidelines-noexcept-destructor,\
+  -cppcoreguidelines-noexcept-move-operations,\
+  -cppcoreguidelines-noexcept-swap,\
+  -cppcoreguidelines-non-private-member-variables-in-classes,\
+  -cppcoreguidelines-use-default-member-init,\
+  -fuchsia-header-anon-namespaces,\
+  -google-readability-braces-around-statements,\
+  -google-readability-function-size,\
+  -google-readability-namespace-comments,\
+  -hicpp-avoid-c-arrays,\
+  -hicpp-avoid-goto,\
+  -hicpp-braces-around-statements,\
+  -hicpp-deprecated-headers,\
+  -hicpp-explicit-conversions,\
+  -hicpp-function-size,\
+  -hicpp-invalid-access-moved,\
+  -hicpp-member-init,\
+  -hicpp-move-const-arg,\
+  -hicpp-named-parameter,\
+  -hicpp-new-delete-operators,\
+  -hicpp-no-array-decay,\
+  -hicpp-no-malloc,\
+  -hicpp-noexcept-move,\
+  -hicpp-special-member-functions,\
+  -hicpp-static-assert,\
+  -hicpp-undelegated-constructor,\
+  -hicpp-uppercase-literal-suffix,\
+  -hicpp-use-auto,\
+  -hicpp-use-emplace,\
+  -hicpp-use-equals-default,\
+  -hicpp-use-equals-delete,\
+  -hicpp-use-noexcept,\
+  -hicpp-use-nullptr,\
+  -hicpp-use-override,\
+  -hicpp-vararg,\
+  -llvm-else-after-return,\
+  -llvm-qualified-auto,\
+  "
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*\.hpp$'
-# AnalyzeTemporaryDtors: false
-FormatStyle: none
+FormatStyle: 'file'
 CheckOptions:
   - key: 'bugprone-argument-comment.StrictMode'
     value: 'true'
@@ -56,6 +270,8 @@ CheckOptions:
     value: '<cmath>'
   - key: 'cppcoreguidelines-narrowing-conversions.PedanticMode'
     value: 'true'
+  - key: 'cppcoreguidelines-pro-type-member-init.UseAssignment'
+    value: 'true'
   - key: 'readability-else-after-return.WarnOnUnfixable'
     value: 'true'
   - key: 'readability-else-after-return.WarnOnConditionVariables'
@@ -68,15 +284,11 @@ CheckOptions:
     value: 'true'
   - key: 'readability-redundant-access-specifiers.CheckFirstDeclaration'
     value: 'true'
-  - key: 'readability-identifier-length.MinimumVariableNameLength'
-    value: 2
-  - key: 'readability-identifier-length.MinimumParameterNameLength'
-    value: 2
-# For variables of generic type T and common physical quantities
+# For variables of generic type T, common physical quantities
   - key: 'readability-identifier-length.IgnoredVariableNames'
-    value: '^(t|T|p|dt|x|y|z|g|v|i)$'
+    value: '^(t|T|p|dt|x|y|z|g|v|i|r)$'
   - key: 'readability-identifier-length.IgnoredParameterNames'
-    value: '^(t|T|p|dt|x|y|z|v)$'
+    value: '^(t|T|p|dt|x|y|z|v|r)$'
 # These seem to be the most common identifier styles
   - key: 'readability-identifier-naming.AbstractClassCase'
     value: 'CamelCase'
@@ -102,8 +314,6 @@ CheckOptions:
     value: 'CamelCase'
   - key: 'readability-identifier-naming.ConstexprVariableCase'
     value: 'camelBack'
-  - key: 'readability-identifier-naming.ConstexprVariableIgnoredRegexp'
-    value: '^T.*$'
   - key: 'readability-identifier-naming.EnumCase'
     value: 'CamelCase'
   - key: 'readability-identifier-naming.EnumConstantCase'
@@ -125,16 +335,12 @@ CheckOptions:
     value: 'camelBack'
   - key: 'readability-identifier-naming.LocalConstantCase'
     value: 'camelBack'
-  - key: 'readability-identifier-naming.LocalConstantIgnoredRegexp'
-    value: '^T.*$'
   - key: 'readability-identifier-naming.LocalConstantPointerCase'
     value: 'camelBack'
   - key: 'readability-identifier-naming.LocalPointerCase'
     value: 'camelBack'
   - key: 'readability-identifier-naming.LocalVariableCase'
     value: 'camelBack'
-  - key: 'readability-identifier-naming.LocalVariableIgnoredRegexp'
-    value: '^T.*$'
   - key: 'readability-identifier-naming.MacroDefinitionCase'
     value: 'UPPER_CASE'
   - key: 'readability-identifier-naming.MemberCase'
@@ -146,8 +352,6 @@ CheckOptions:
     value: 'camelBack'
   - key: 'readability-identifier-naming.ParameterCase'
     value: 'camelBack'
-  - key: 'readability-identifier-naming.ParameterIgnoredRegexp'
-    value: '^T.*$'
   - key: 'readability-identifier-naming.ParameterPackCase'
     value: 'camelBack'
   - key: 'readability-identifier-naming.PointerParameterCase'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -246,7 +246,7 @@ Checks: "*,\
   -llvm-qualified-auto,\
   "
 WarningsAsErrors: ''
-HeaderFilterRegex: '.*\.hpp$'
+HeaderFilterRegex: '.*\.[hi]pp$'
 FormatStyle: 'file'
 CheckOptions:
   - key: 'bugprone-argument-comment.StrictMode'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,20 @@ on:
       - main
 
 env:
-  CMAKE_VERSION: "3.29.6"
   VCPKG_COMMITTISH: 49ac2134b31b95b0ddf29d56873dcd24392691df
 
 jobs:
-  format-and-spell:
+  check-formatting-and-spelling:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install codespell and cmake-format
-        run: pipx install codespell cmakelang
+      - name: Set up tools
+        run: |
+          sudo apt update -q
+          sudo apt install -y clang-format-19
+          pipx install cmakelang codespell
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-19 9999
 
       - name: Print versions
         run: |
@@ -27,33 +30,35 @@ jobs:
           pipx --version
           cmake --version
           clang-format --version
+          clang-format-19 --version
           cmake-format --version
           codespell --version
 
-      - name: Format code
+      - name: Check code formatting
         run: cmake -P CMake/Format.cmake
 
-      - name: Spell check
+      - name: Check spelling
         run: cmake -P CMake/Spell.cmake
 
   test-windows:
-    needs: format-and-spell
+    needs: check-formatting-and-spelling
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up build tools
+      - name: Set up MSVC environment
         uses: aminya/setup-cpp@v1
         with:
           vcvarsall: true
-          cmake: ${{ env.CMAKE_VERSION }}
-          ninja: true
 
-      - name: Print version of build tools
+      - name: Print versions
         run: |
           cmake --version
           ninja --version
+          cl --version || true
+          clang-cl --version || true
 
+        # TODO: Think about removing VCPKG_COMMITTISH from the cache key
       - name: Set up vcpkg
         uses: fantana21/set-up-vcpkg@v1
         with:
@@ -71,7 +76,7 @@ jobs:
         run: |
           "url=https://github.com`nusername=AllRepositories`npassword=${{ secrets.ALL_REPOSITORIES_PAT }}`n" | git credential approve
 
-      - name: Set up MultiToolTask
+      - name: Improve parallelism of MSBuild
         run: |
           Add-Content "$env:GITHUB_ENV" 'UseMultiToolTask=true'
           Add-Content "$env:GITHUB_ENV" 'EnforceProcessCountAcrossBuilds=true'
@@ -104,18 +109,27 @@ jobs:
           pr-comment-header: windows warnings report
 
   test-ubuntu:
-    needs: format-and-spell
+    needs: check-formatting-and-spelling
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install tools
+      - name: Set up tools
         run: |
-          sudo apt-get update -q
-          sudo apt-get install -y cppcheck ninja-build valgrind llvm
+          sudo apt update -q
+          sudo apt install -y gcc-14 g++-14
+          sudo apt install -y clang-19 clang-tidy-19 llvm-19
+          sudo apt install -y cppcheck valgrind
           pipx install gcovr
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 9999
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 9999
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-14 9999
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 9999
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 9999
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-19 9999
+          sudo update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-19 9999
 
-      - name: Print and store version info
+      - name: Print and store versions
         shell: pwsh
         run: |
           g++ --version

--- a/CMake/AddAndSetUpTargets.cmake
+++ b/CMake/AddAndSetUpTargets.cmake
@@ -71,6 +71,6 @@ function(_set_include_directories_and_cxx_standard target scope)
     target_include_directories(
         ${target} ${warning_guard} ${scope} "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
     )
-    target_compile_features(${target} ${scope} cxx_std_20)
+    target_compile_features(${target} ${scope} cxx_std_23)
     set_property(TARGET ${target} PROPERTY CXX_EXTENSIONS OFF)
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.31)
 
 include(CMake/Prelude.cmake)
 include(CMake/MetadataFromVcpkg.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ project(
     LANGUAGES CXX
 )
 
+# Disable scanning for modules because we don't use them and this causes errors when running clang
+# tools while compiling with GCC
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 include(CMake/OptionsAndVariables.cmake)
 include(CMake/AddAndSetUpTargets.cmake)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,7 +24,7 @@
       "description": "This preset makes sure the project actually builds with at least the specified standard",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CXX_STANDARD": "23",
         "CMAKE_CXX_STANDARD_REQUIRED": "ON",
         "CMAKE_CXX_EXTENSIONS": "OFF"
       }

--- a/CppProjectTemplate/Library.cpp
+++ b/CppProjectTemplate/Library.cpp
@@ -5,6 +5,8 @@
 #include <string>
 
 
+namespace cpt
+{
 Library::Library() : name_{fmt::format("{}", "CppProjectTemplate")}
 {}
 
@@ -13,4 +15,5 @@ auto Library::Name() const -> std::string
 {
     int unusedAndUninizialiedVariable;
     return name_;
+}
 }

--- a/CppProjectTemplate/Library.hpp
+++ b/CppProjectTemplate/Library.hpp
@@ -3,6 +3,8 @@
 #include <string>
 
 
+namespace cpt
+{
 //! @brief The core implementation of the executable
 //!
 //! This class makes up the library part of the executable, which means that the main logic is
@@ -20,3 +22,4 @@ public:
 private:
     std::string name_;
 };
+}

--- a/CppProjectTemplate/Main.cpp
+++ b/CppProjectTemplate/Main.cpp
@@ -8,12 +8,15 @@
 #include <iostream>
 
 
+namespace
+{
 using Number = fluent::NamedType<int, struct NumberTag, fluent::Addable, fluent::Printable>;
 
 
 auto Increment(Number number) -> Number
 {
     return number + Number(1);
+}
 }
 
 

--- a/CppProjectTemplate/Main.cpp
+++ b/CppProjectTemplate/Main.cpp
@@ -24,10 +24,10 @@ auto main() -> int
 {
     try
     {
-        auto const library = Library{};
+        auto const library = cpt::Library{};
         auto const message = "Hello from " + library.Name() + "!";
         std::cout << message << "\n";
-        std::cout << "Square(2) = " << Square(2) << "\n";
+        std::cout << "Square(2) = " << cpt::Square(2) << "\n";
         auto const number = Number(41);
         std::cout << Increment(number) << "\n";
         std::cout << "quantnd::allAreEqual<1, 1, 1> = " << quantnd::allAreEqual<1, 1, 1> << "\n";

--- a/CppProjectTemplate/Square.hpp
+++ b/CppProjectTemplate/Square.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 
+namespace cpt
+{
 template<typename T>
 constexpr auto Square(T value) -> decltype(value * value)
 {
     return value * value;
+}
 }

--- a/CppProjectTemplate/Square.hpp
+++ b/CppProjectTemplate/Square.hpp
@@ -4,8 +4,8 @@
 namespace cpt
 {
 template<typename T>
-constexpr auto Square(T value) -> decltype(value * value)
-{
-    return value * value;
+constexpr auto Square(T value) -> decltype(value * value);
 }
-}
+
+
+#include <CppProjectTemplate/Square.ipp>

--- a/CppProjectTemplate/Square.ipp
+++ b/CppProjectTemplate/Square.ipp
@@ -1,0 +1,14 @@
+#pragma once
+
+// IWYU pragma: private, include <CppProjectTemplate/Square.hpp>
+#include <CppProjectTemplate/Square.hpp>
+
+
+namespace cpt
+{
+template<typename T>
+constexpr auto Square(T value) -> decltype(value * value)
+{
+    return value * value;
+}
+}

--- a/Tests/Library.test.cpp
+++ b/Tests/Library.test.cpp
@@ -2,8 +2,6 @@
 
 #include <doctest/doctest.h>
 
-#include <string>
-
 
 TEST_CASE("Library name is CppProjectTemplate")
 {

--- a/Tests/Library.test.cpp
+++ b/Tests/Library.test.cpp
@@ -5,6 +5,6 @@
 
 TEST_CASE("Library name is CppProjectTemplate")
 {
-    auto const library = Library{};
+    auto const library = cpt::Library{};
     CHECK(library.Name() == "CppProjectTemplate");
 }

--- a/Tests/Square.test.cpp
+++ b/Tests/Square.test.cpp
@@ -5,8 +5,8 @@
 
 TEST_CASE("Square")
 {
-    CHECK(Square(0) == 0);
-    CHECK(Square(1.0F) == 1.0F);
-    CHECK(Square(17.3) == 17.3 * 17.3);
-    CHECK(Square(-2000) == 4'000'000);
+    CHECK(cpt::Square(0) == 0);
+    CHECK(cpt::Square(1.0F) == 1.0F);
+    CHECK(cpt::Square(17.3) == 17.3 * 17.3);
+    CHECK(cpt::Square(-2000) == 4'000'000);
 }

--- a/Tests/Square.test.cpp
+++ b/Tests/Square.test.cpp
@@ -8,5 +8,5 @@ TEST_CASE("Square")
     CHECK(Square(0) == 0);
     CHECK(Square(1.0F) == 1.0F);
     CHECK(Square(17.3) == 17.3 * 17.3);
-    CHECK(Square(-2'000) == 4'000'000);
+    CHECK(Square(-2000) == 4'000'000);
 }


### PR DESCRIPTION
Fixes #67 

- Update the config files for the Clang tools
- Make everything build with the new compilers, tools, and C++ standard
- Update the CI workflow to use the new versions
- Add `Square.ipp` to show how we handle those files (especially with clang-tidy's include cleaner)
- Move the library code into its own namespace (`cpt`) because that's good C++ practice