### PR TITLE
Use `.valgrindrc` for specifying Valgrind options

### DIFF
--- a/.valgrindrc
+++ b/.valgrindrc
@@ -1,0 +1,5 @@
+--memcheck:leak-check=full
+--memcheck:show-leak-kinds=all
+--memcheck:track-origins=yes
+--memcheck:errors-for-leak-kinds=all
+--memcheck:error-exitcode=1

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,3 +1,15 @@
 set(MEMORYCHECK_TYPE Valgrind)
-# If --errors-for-leak-kinds=all is too strict, try --errors-for-leak-kinds=definite
-set(VALGRIND_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all --track-origins=yes --errors-for-leak-kinds=all --error-exitcode=1")
+# Read the Valgrind options from .valgrindrc. This is done at configure time so rerun CMake after
+# making changes to .valgrindrc. If --errors-for-leak-kinds=all is too strict, try
+# --errors-for-leak-kinds=definite
+file(READ "${CMAKE_SOURCE_DIR}/.valgrindrc" VALGRIND_OPTIONS)
+string(STRIP "${VALGRIND_OPTIONS}" VALGRIND_OPTIONS)
+string(REPLACE "\n" " " VALGRIND_OPTIONS "${VALGRIND_OPTIONS}")
+string(
+    REPLACE
+    "--memcheck:suppressions="
+    "--memcheck:suppressions=${CMAKE_SOURCE_DIR}/"
+    VALGRIND_OPTIONS
+    "${VALGRIND_OPTIONS}"
+)
+set(VALGRIND_COMMAND_OPTIONS "${VALGRIND_OPTIONS}")


### PR DESCRIPTION
Fixes #74 