### PR TITLE
Fix using clang-tidy-cache

### DIFF
--- a/CMake/DeveloperMode.cmake
+++ b/CMake/DeveloperMode.cmake
@@ -10,11 +10,6 @@ if(ENABLE_COVERAGE)
     include(CMake/Coverage.cmake)
 endif()
 
-option(CppProjectTemplate_ENABLE_CLANG_TIDY_CACHE "Speed up reanalysis with clang-tidy-cache" ON)
-if(CppProjectTemplate_ENABLE_CLANG_TIDY_CACHE)
-    include(CMake/ClangTidyCache.cmake)
-endif()
-
 # Further options for developers go here
 
 include(CMake/FormatTargets.cmake)

--- a/CMake/OptionsAndVariables.cmake
+++ b/CMake/OptionsAndVariables.cmake
@@ -1,5 +1,6 @@
-# This file contains user options and variables. Developer-specific options and variables should be
-# placed in CMake/DeveloperMode.cmake.
+# This file defines all user-configurable options and variables for the project. It also includes
+# developer-specific options and variables that must be set before any targets are created.
+# Additional developer-specific options and variables should be placed in CMake/DeveloperMode.cmake.
 
 if(PROJECT_IS_TOP_LEVEL)
     # Developer mode enables targets and code paths in the CMake scripts that are only relevant for
@@ -13,7 +14,16 @@ if(PROJECT_IS_TOP_LEVEL)
     endif()
 endif()
 
-# ---- Warning guard ----
+if(CppProjectTemplate_DEVELOPER_MODE)
+    option(
+        CppProjectTemplate_ENABLE_CLANG_TIDY_CACHE
+        "Speed up reanalysis with clang-tidy-cache"
+        ON
+    )
+    if(CppProjectTemplate_ENABLE_CLANG_TIDY_CACHE)
+        include(CMake/ClangTidyCache.cmake)
+    endif()
+endif()
 
 # target_include_directories() with the SYSTEM modifier will request the compiler to omit warnings
 # from the provided paths, if the compiler supports that. This is to provide a user experience


### PR DESCRIPTION
In 07b74fa76a3f4e75a74cd2bcaec37cbf9270195c I moved the option for enabling clang-tidy-cache to the developer options in `DeveloperMode.cmake`. This was a mistake because that file is included after the targets are defined, but to enable clang-tidy-cache we need to modify `CMAKE_CXX_CLANG_TIDY` which only effects targets defined after its change.