### PR TITLE
docs(.clang-format): 'stdandard' -> 'standard' in include-group comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -97,10 +97,10 @@ IncludeCategories:
   # Parsing is done in the order defined here, so this is not ordered by priority but specificity of
   # the regex. The main header for a source file is automatically assigned priority 0.
   #
-  # C stdandard library
+  # C standard library
   - Regex: '^<(assert|complex|ctype|ctype|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdatomic|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>'
     Priority: 4
-  # C++ stdandard library: <*> without extension
+  # C++ standard library: <*> without extension
   - Regex: '^<[a-z_]+>'
     Priority: 3
   # CppProjectTemplate header files <CppProjectTemplate/*.hpp> without underscores or hyphens


### PR DESCRIPTION
## Summary

\`.clang-format\` had \"stdandard\" in two comments identifying the C and C++ standard library include groups. Fixed both occurrences.

Closes #93