### PR TITLE
Update .clang-tidy and .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -97,10 +97,10 @@ IncludeCategories:
   # Parsing is done in the order defined here, so this is not ordered by priority but specificity of
   # the regex. The main header for a source file is automatically assigned priority 0.
   #
-  # C stdandard library
+  # C standard library
   - Regex: '^<(assert|complex|ctype|ctype|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdatomic|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>'
     Priority: 4
-  # C++ stdandard library: <*> without extension
+  # C++ standard library: <*> without extension
   - Regex: '^<[a-z_]+>'
     Priority: 3
   # CppProjectTemplate header files <CppProjectTemplate/*.hpp> without underscores or hyphens

--- a/.clang-format
+++ b/.clang-format
@@ -256,7 +256,7 @@ SpacesInParensOptions:
   InEmptyParentheses:      false
   Other:                   false
 SpacesInSquareBrackets: false
-Standard: Auto
+Standard: Latest
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,7 @@
 # - Android
 # - Boost
 # - Darwin (Apple platforms)
-# - Fuchisa (but the inheritance checks are use)
+# - Fuchsia (but the inheritance checks are useful)
 # - Google Test
 # - Objective-C (google-objc)
 # - Linux kernel
@@ -28,6 +28,8 @@
 #   doesn't sound like an important check.
 # - google-readability-todo: We don't require names and/or bug numbers in TODO comments.
 # - google-runtime-int: We don't require using std::int32_t, etc. instead of int, long, ...
+# - hicpp-signed-bitwise: It's not useful because it checks the wrong things. See
+#   https://stackoverflow.com/a/58845898.
 # - misc-const-correctness: It's not about const-correctness, but about const-ness of local
 #   variables and I am not on the const-all-the-things bandwagon.
 # - misc-header-include-cycle: Triggers in our .ipp files. For some reason I can't disable the
@@ -65,6 +67,7 @@ Checks: "*,\
   fuchsia-virtual-inheritance,\
   -google-readability-todo,\
   -google-runtime-int,\
+  -hicpp-signed-bitwise,\
   -misc-const-correctness,\
   -misc-header-include-cycle,\
   -modernize-use-designated-initializers,\


### PR DESCRIPTION
Fixes #92
Fixes #93 

Also sets the `Standard` in `.clang-format` to `Latest` to ensure that no spaces are added between angle brackets of nested templates (they were necessary before C++11 and `Auto` seems to not always detect the right standard).