### PR TITLE
Switch from doctest to Catch2

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,8 +22,6 @@
 # - avoid-c-arrays: C arrays are fine if used only locally.
 # - bugprone-implicit-widening-of-multiplication-result: I am not sure anymore but I think this is
 #   too noisy.
-# - clang-analyzer-cplusplus.NewDeleteLeaks: I don't know how to silence potential false positives
-#   that it found in doctest.h, so I disable it completely. Also, we have Valgrind anyway.
 # - clang-diagnostic-unused-command-line-argument: I don't remember why I disabled this, but it
 #   doesn't sound like an important check.
 # - google-readability-todo: We don't require names and/or bug numbers in TODO comments.
@@ -61,7 +59,6 @@ Checks: "*,\
   -openmp-*,\
   -*avoid-c-arrays,\
   -bugprone-implicit-widening-of-multiplication-result,\
-  -clang-analyzer-cplusplus.NewDeleteLeaks,\
   -clang-diagnostic-unused-command-line-argument,\
   fuchsia-multiple-inheritance,\
   fuchsia-virtual-inheritance,\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   LLVM_MAJOR_VERSION: '20'
+  # TODO: Upgrade this and the dependencies in vcpkg.json
   VCPKG_COMMITTISH: dd3097e305afa53f7b4312371f62058d2e665320  # 2025.07.25
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ on:
 
 env:
   LLVM_MAJOR_VERSION: '20'
-  # TODO: Upgrade this and the dependencies in vcpkg.json
-  VCPKG_COMMITTISH: dd3097e305afa53f7b4312371f62058d2e665320  # 2025.07.25
+  VCPKG_COMMITTISH: 56bb2411609227288b70117ead2c47585ba07713  # 2026.04.27
 
 jobs:
   check-formatting-and-spelling:

--- a/CMake/GersemiStubs.cmake
+++ b/CMake/GersemiStubs.cmake
@@ -1,2 +1,2 @@
-function(doctest_discover_tests TARGET)
+function(catch_discover_tests TARGET)
 endfunction()

--- a/CppProjectTemplate/Person.cpp
+++ b/CppProjectTemplate/Person.cpp
@@ -1,6 +1,6 @@
 #include <CppProjectTemplate/Person.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <string>
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ preferences. The following is a non-exhaustive list of changes.
 - Move project-independent CMake code to our [Infrastructure
   repository](https://github.com/fantana21/Infrastructure) and add it as a submodule. This
   makes it easier to maintain and improve the code.
-- Use [doctest](https://github.com/doctest/doctest) instead of
-  [Catch2](https://github.com/catchorg/Catch2).
 - Support [ccache](https://ccache.dev/) and
   [clang-tidy-cache](https://github.com/matus-chochlik/ctcache). The options
   `CppProjectTemplate_ENABLE_CCACHE` and `CppProjectTemplate_ENABLE_CLANG_TIDY_CACHE` are

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,24 +1,23 @@
 # ---- Dependencies ----
 
-find_package(doctest CONFIG REQUIRED)
-include(doctest)
-include(../Infrastructure/CMake/DoctestWithMain.cmake)
+find_package(Catch2 CONFIG REQUIRED)
+include(Catch)
 
 # ---- Tests ----
 
 add_fantana_test(CppProjectTemplateTests_Person)
 target_link_libraries(
     CppProjectTemplateTests_Person
-    PRIVATE CppProjectTemplate::Person doctest::doctestWithMain
+    PRIVATE Catch2::Catch2WithMain CppProjectTemplate::Person
 )
-doctest_discover_tests(CppProjectTemplateTests_Person)
+catch_discover_tests(CppProjectTemplateTests_Person)
 
 add_fantana_test(CppProjectTemplateTests_Square)
 target_link_libraries(
     CppProjectTemplateTests_Square
-    PRIVATE CppProjectTemplate::Square doctest::doctestWithMain
+    PRIVATE Catch2::Catch2WithMain CppProjectTemplate::Square
 )
-doctest_discover_tests(CppProjectTemplateTests_Square)
+catch_discover_tests(CppProjectTemplateTests_Square)
 
 # ---- End-of-file commands ----
 

--- a/Tests/Person.test.cpp
+++ b/Tests/Person.test.cpp
@@ -1,6 +1,6 @@
 #include <CppProjectTemplate/Person.hpp>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 
 TEST_CASE("Person name is John Doe")

--- a/Tests/Square.test.cpp
+++ b/Tests/Square.test.cpp
@@ -1,6 +1,6 @@
 #include <CppProjectTemplate/Square.hpp>
 
-#include <doctest/doctest.h>
+#include <catch2/catch_test_macros.hpp>
 
 
 TEST_CASE("Square")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "name": "fmt",
-      "version>=": "10.2.1#1"
+      "version>=": "12.1.0"
     },
     {
       "name": "namedtype",
@@ -14,7 +14,7 @@
     },
     {
       "name": "quantnd",
-      "version>=": "0.1.0"
+      "version>=": "0.6.0"
     }
   ],
   "features": {
@@ -23,7 +23,7 @@
       "dependencies": [
         {
           "name": "catch2",
-          "version>=": "3.8.1"
+          "version>=": "3.14.0"
         }
       ]
     }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,8 +22,8 @@
       "description": "Dependencies for testing",
       "dependencies": [
         {
-          "name": "doctest",
-          "version>=": "2.4.11"
+          "name": "catch2",
+          "version>=": "3.8.1"
         }
       ]
     }


### PR DESCRIPTION
Fixes #90 

Also, updates the vcpkg committish in the CI workflow. The dependencies are updated accordingly.